### PR TITLE
Polarizable escape time actualization

### DIFF
--- a/structured/Components.json
+++ b/structured/Components.json
@@ -2,7 +2,8 @@
     "GlobalData": {
         "Units": [
             ["Units", "None", "None.cu"],
-            ["Units", "KcalMol_A", "KcalMol_A.cu"]
+            ["Units", "KcalMol_A", "KcalMol_A.cu"],
+            ["Units", "lenSI", "lenSI.cu"]
         ],
         "Types": [
             ["Types", "Basic", "Basic.cu"],
@@ -74,7 +75,8 @@
             ["GeometricalMeasure", "MeanSquareDisplacement", "MeanSquareDisplacement.cu"],
             ["GeometricalMeasure", "MeanAngularCorrelation", "MeanAngularCorrelation.cu"],
             ["GeometricalMeasure", "CenterOfMassPosition", "CenterOfMassPosition.cu"],
-            ["GeometricalMeasure", "EscapeTime", "EscapeTime.cu"],
+            ["GeometricalMeasure", "EscapePolygonTime", "EscapeTime.cu"],
+            ["GeometricalMeasure", "EscapeSphereTime", "EscapeTime.cu"],
             ["GeometricalMeasure", "Height", "Height.cu"],
             ["TopologicalMeasures", "PatchPolymers", "PatchPolymers.cu"],
             ["ParticlesListMeasure", "PotentialMeasure", "PotentialMeasure.cu"],

--- a/structured/src/GlobalData/Units/Units/KcalMol_A.cu
+++ b/structured/src/GlobalData/Units/Units/KcalMol_A.cu
@@ -11,7 +11,7 @@ namespace Units{
 
             KcalMol_A(DataEntry& data):UnitsHandler(data){}
 
-            real getBoltzmannConstant()        override {return 1.987191E-03;}
+            real getBoltzmannConstant()        override {return 1.987191e-03;}
             real getElectricConversionFactor() override {return 332.0716;}
     };
 

--- a/structured/src/GlobalData/Units/Units/KcalMol_A.cu
+++ b/structured/src/GlobalData/Units/Units/KcalMol_A.cu
@@ -11,7 +11,7 @@ namespace Units{
 
             KcalMol_A(DataEntry& data):UnitsHandler(data){}
 
-            real getBoltzmannConstant()        override {return 1.987191e-03;}
+            real getBoltzmannConstant()        override {return 1.987191E-03;}
             real getElectricConversionFactor() override {return 332.0716;}
     };
 

--- a/structured/src/GlobalData/Units/Units/lenSI.cu
+++ b/structured/src/GlobalData/Units/Units/lenSI.cu
@@ -1,0 +1,41 @@
+#include "GlobalData/Units/UnitsHandler.cuh"
+#include "GlobalData/Units/UnitsFactory.cuh"
+
+namespace uammd{
+namespace structured{
+namespace Units{
+
+    class lenSI: public UnitsHandler{
+        /*
+           International System units, have a parameter lenghtScale to scale the Lenght.
+
+           length      = lenghtScale  m
+           mass        = lenghScale^3 g  (because mass scale with volume)
+           time        = lenghtScale  s  (So energy scale with volume)
+           charge      = lenghtScale  C  (So voltage is in Volts)
+           Temperature = Kelvin
+
+           */
+            real scale3;
+            real scale2;
+
+
+        public:
+
+            lenSI(DataEntry& data):UnitsHandler(data){
+
+                real scale  = data.getParameter<real>("lengthScale",1.0);
+                scale3 = scale*scale*scale;
+                scale2 = scale*scale;
+            }
+
+            real getBoltzmannConstant()        override {return 1.380649e-23/scale3;} // scale3 J/K
+            real getElectricConversionFactor() override {return 8.987551e9*scale2;} // scale-2 N m^2 C^-2
+    };
+
+}}}
+
+REGISTER_UNITS(
+    Units,lenSI,
+    uammd::structured::Units::lenSI
+)

--- a/structured/src/Interactor/Single/External/PolarizationTabulated.cu
+++ b/structured/src/Interactor/Single/External/PolarizationTabulated.cu
@@ -16,16 +16,33 @@ namespace External{
 
     struct PolarizationTabulated_: public ExternalTabulated_{
 
-        using StorageData = ExternalTabulated_::StorageData;
+        struct StorageData : public ExternalTabulated_::StorageData {
+            real eps;
+
+        };
 
         static __host__ StorageData getStorageData(std::shared_ptr<GlobalData> gd,
                                                    std::shared_ptr<ParticleGroup> pg,
                                                    DataEntry& data) {
-            return ExternalTabulated_::getStorageData(gd, pg, data);
+
+            StorageData storage;
+
+            static_cast<ExternalTabulated_::StorageData&>(storage) =
+                ExternalTabulated_::getStorageData(gd,pg,data);
+
+            // Set eps
+
+            real f = gd->getUnits()->getElectricConversionFactor();
+            real dielectricConstant = data.getParameter<real>("dielectricConstant");
+            storage.eps = dielectricConstant/(4*M_PI*f);
+
+            return storage;
         };
 
         struct ComputationalData : public ExternalTabulated_::ComputationalData {
             real* polarizability;
+            real eps;
+
         };
 
         static __host__ ComputationalData getComputationalData(std::shared_ptr<GlobalData>    gd,
@@ -44,17 +61,21 @@ namespace External{
             std::shared_ptr<ParticleData> pd = pg->getParticleData();
             computational.polarizability = pd->getPolarizability(access::location::gpu, access::mode::read).raw();
 
+            // Set eps
+
+            computational.eps = storage.eps;
+
             return computational;
         };
 
         static inline __device__ real energy(int index_i,const ComputationalData& computational){
                 real e = ExternalTabulated_::energy(index_i, computational);
-                return e*computational.polarizability[index_i];
+                return e*computational.eps*computational.polarizability[index_i];
         }
 
         static inline __device__ real3 force(int index_i,const ComputationalData& computational){
                 real3 f = ExternalTabulated_::force(index_i, computational);
-                return f*computational.polarizability[index_i];
+                return f*computational.eps*computational.polarizability[index_i];
         }
 
     };

--- a/structured/src/SimulationStep/SimulationMeasures/GeometricalMeasure/EscapeTime.cu
+++ b/structured/src/SimulationStep/SimulationMeasures/GeometricalMeasure/EscapeTime.cu
@@ -179,7 +179,9 @@ class EscapeTime: public SimulationStepBase{
                     isParticleInsideSystem[index] = false;
                     particlesIn++;
                     if(stopSimulation and (particlesIn >= particlesToEscape)){
-                        System::log<System::CRITICAL>("[EscapeTime] Simulation interrumpted, all particles have escaped");
+                        //System::log<System::CRITICAL>("[EscapeTime] Simulation interrumpted, all particles have escaped");
+                        System::log<System::MESSAGE>("[EscapeTime] All particlesToEscape have escaped!");
+                        this->sys->setState(ExtendedSystem::SIMULATION_STATE::STOPPED);
                     }
                 }
             }

--- a/structured/src/SimulationStep/SimulationMeasures/GeometricalMeasure/EscapeTime.cu
+++ b/structured/src/SimulationStep/SimulationMeasures/GeometricalMeasure/EscapeTime.cu
@@ -11,33 +11,125 @@ namespace structured{
 namespace SimulationStep{
 namespace SimulationMeasures{
 
-class insideSystemChecker{
-        private:
-                std::vector<real3> normalVector;
-                std::vector<real3> independentVector;
-        public:
-                insideSystemChecker(std::vector<real3> normalVector, std::vector<real3> independentVector):normalVector(normalVector),independentVector(independentVector){}
-                bool isInsideSystem(real3 pos){ //Check if the particle is below all the planes contained in normalVector and independentVector. By computing the dot product of normalVector * (pos-independentVector)
-                    bool isInside = true;
-                    for (int plane = 0; plane < normalVector.size(); plane++){
-                        real3 particlePositionMinusIndependentVector = pos - independentVector[plane];
-                        real dotProduct = dot(normalVector[plane],particlePositionMinusIndependentVector);
 
-                        if(dotProduct < 0){
-                            isInside = false;
-                        }
-                    }
-                    return isInside;
-                }
+class insideCheckerBase_{
+    public:
+        virtual bool isInsideSystem(real3 pos){
+            return false;
+        }
 };
 
+class insideSphereChecker{
+    private:
+        std::vector<real3> center;
+        std::vector<real> radius2;
+        std::string logicalSum;
+    public:
+        insideSphereChecker(DataEntry& data){
+            //Read Data from input file.
+            auto centerData = data.getData<real3>("center");
+            auto radiusData = data.getData<real>("radius");
+            logicalSum      = data.getParameter<std::string>("logicalSum","all");
+            if(logicalSum!="all" and logicalSum!="any"){
+                System::log<System::CRITICAL>("[EscapeSphereTime] logicalSum must be 'any' or 'all' ");
+            }
+
+            for (int i = 0; i < centerData.size(); i++){
+                center.push_back({centerData[i].x,centerData[i].y,centerData[i].z});
+                radius2.push_back({radiusData[i]*radiusData[i]});
+            }
+        }
+    private:
+        bool isInsideAll(real3 pos){ //Check if the particle is inside ALL the spheres, not any.
+            for (int sphere = 0; sphere < center.size(); sphere++){
+                real3 diff = pos - center[sphere];
+                real diff2 = dot(diff,diff);
+
+                if(diff2 > radius2[sphere]){
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        bool isInsideAny(real3 pos){ //Check if the particle is inside ANY sphere, not all.
+            for (int sphere = 0; sphere < center.size(); sphere++){
+                real3 diff = pos - center[sphere];
+                real diff2 = dot(diff,diff);
+
+                if(diff2 < radius2[sphere]){
+                    return true;
+                }
+            }
+            return false;
+        }
+
+    public:
+        bool isInsideSystem(real3 pos){
+            if(logicalSum == "all"){
+                return isInsideAll(pos);
+            }
+
+            if(logicalSum == "any"){
+                return isInsideAny(pos);
+            }
+            System::log<System::CRITICAL>("[EscapeSphereTime] logicalSum must be 'any' or 'all' ");
+            return false;
+        }
+
+};
+
+class insidePolygonChecker{
+    private:
+        std::vector<real3> normalVector;
+        std::vector<real3> independentVector;
+    public:
+        insidePolygonChecker(DataEntry& data){
+            //Read Data from input file.
+            auto normalVectorData      = data.getData<real3>("normalVector");
+            auto independentVectorData = data.getData<real3>("independentVector");
+
+            for (int i = 0; i < normalVectorData.size(); i++){
+                normalVector.push_back({normalVectorData[i].x,normalVectorData[i].y,normalVectorData[i].z});
+                independentVector.push_back({independentVectorData[i].x,independentVectorData[i].y,independentVectorData[i].z});
+            }
+        }
+
+        bool isInsideSystem(real3 pos){ //Check if the particle is below all the planes contained in normalVector and independentVector. By computing the dot product of normalVector * (pos-independentVector)
+            for (int plane = 0; plane < normalVector.size(); plane++){
+                real3 particlePositionMinusIndependentVector = pos - independentVector[plane];
+                real dotProduct = dot(normalVector[plane],particlePositionMinusIndependentVector);
+
+                if(dotProduct < 0){
+                    return false;
+                }
+            }
+            return true;
+        }
+};
+
+bool stringToBool(const std::string& str) {
+    if (str == "true") {
+        return true;
+    } else if (str == "false") {
+        return false;
+    } else {
+        System::log<System::CRITICAL>("[EscapeTime] stopSimulation must be 'true' or 'false'");
+    }
+}
+
+template <class InsideSystemChecker>
 class EscapeTime: public SimulationStepBase{
 
         std::string   outputFilePath;
         std::ofstream outputFile;
 
-        std::shared_ptr<insideSystemChecker> checker;
+        bool stopSimulation;
+        std::shared_ptr<InsideSystemChecker> checker;
         std::map<int,bool> isParticleInsideSystem;
+
+        int particlesIn = 0;
+        int particlesToEscape;
 
     public:
 
@@ -50,21 +142,13 @@ class EscapeTime: public SimulationStepBase{
             //Read parameters from input file.
             outputFilePath = data.getParameter<std::string>("outputFilePath");
 
-            //Read Data from input file.
-            auto normalVectorData      = data.getData<real3>("normalVector");
-            auto independentVectorData = data.getData<real3>("independentVector");
-
-            std::vector<real3> normalVector;
-            std::vector<real3> independentVector;
-
-            for (int i = 0; i < normalVectorData.size(); i++){
-                normalVector.push_back({normalVectorData[i].x,normalVectorData[i].y,normalVectorData[i].z});
-                independentVector.push_back({independentVectorData[i].x,independentVectorData[i].y,independentVectorData[i].z});
-            }
-
-            checker = std::make_shared<insideSystemChecker>(normalVector,independentVector);
+            checker = std::make_shared<InsideSystemChecker>(data);
 
             auto pos = pd->getPos(access::location::cpu, access::mode::read);
+
+            stopSimulation  = stringToBool(data.getParameter<std::string>("stopSimulation","false"));
+            particlesToEscape = data.getParameter<int>("particlesToEscape",pos.size());
+
             const int *sortedIndex = pd->getIdOrderedIndices(access::location::cpu);
             for(int i = 0; i < pos.size(); i++){
                 int index = sortedIndex[i];
@@ -72,6 +156,7 @@ class EscapeTime: public SimulationStepBase{
                 isParticleInsideSystem[index] = checker->isInsideSystem(particlePosition);
                 if (!isParticleInsideSystem[index]){
                     outputFile << 0 << " " << index << std::endl;
+                    particlesIn++;
                 }
             }
         }
@@ -82,7 +167,6 @@ class EscapeTime: public SimulationStepBase{
         }
 
         void applyStep(ullint step, cudaStream_t st) override{
-
             auto pos = pd->getPos(access::location::cpu, access::mode::read);
             const int *sortedIndex = pd->getIdOrderedIndices(access::location::cpu);
             for(int i = 0; i < pos.size(); i++){
@@ -93,15 +177,26 @@ class EscapeTime: public SimulationStepBase{
                 if(isParticleInsideSystem[index] && !isInsideSystem){
                     outputFile << step << " " << index << std::endl;
                     isParticleInsideSystem[index] = false;
+                    particlesIn++;
+                    if(stopSimulation and (particlesIn >= particlesToEscape)){
+                        System::log<System::CRITICAL>("[EscapeTime] Simulation interrumpted, all particles have escaped");
+                    }
                 }
             }
-
         }
 };
 
 }}}}
 
+using insideSphereChecker = uammd::structured::SimulationStep::SimulationMeasures::insideSphereChecker;
+using insidePolygonChecker = uammd::structured::SimulationStep::SimulationMeasures::insidePolygonChecker;
+
 REGISTER_SIMULATION_STEP(
-    GeometricalMeasure,EscapeTime,
-    uammd::structured::SimulationStep::SimulationMeasures::EscapeTime
+    GeometricalMeasure,EscapeSphereTime,
+    uammd::structured::SimulationStep::SimulationMeasures::EscapeTime<insideSphereChecker>
+)
+
+REGISTER_SIMULATION_STEP(
+    GeometricalMeasure,EscapePolygonTime,
+    uammd::structured::SimulationStep::SimulationMeasures::EscapeTime<insidePolygonChecker>
 )


### PR DESCRIPTION
Added lenSI units, a system of units based on the SI that scales with a parameter, the tipical length of the system.

Added stopSimulation parameter to EscapeTime so the simulation ends when the particles
that escaped the system are equal to a given parameter particlesToEscape. Both parameters are
optionals. If not defined stopSimulation is false, and particlesToEscape is total number of particles.

Added dielectricConstant to PolarizableTabulated.cu
