### PR TITLE
Restrict CI to just two cores so it does not run out of RAM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,6 @@ jobs:
         micromamba activate uammd
         mkdir build && cd build
         cmake -DCMAKE_VERBOSE_MAKEFILE=yes -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DCMAKE_CUDA_ARCHITECTURES=OFF -DBUILD_PYTHON_WRAPPER=ON -DINSTALL_PYTHON_PACKAGE=ON ..
-        make -j install
+        make -j 2 install
 
       shell: micromamba-shell {0}


### PR DESCRIPTION
CI is failling because the runner uses too much cores and runs out of RAM. This PR sets compilation to just two cores.