### PR TITLE
Incompatible with CUDA >=12.8

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - cmake >=3.27
-  - cuda-version 12.*
+  - cuda-version < 12.8
   - gxx 11.*
   - gcc
   - cuda-libraries-dev


### PR DESCRIPTION
I restrict the CUDA version to 12.8. Currently, compilation fails with CUDA 12.9 due to this version defining an atomicAdd overload for float2. Given that UAMMD already defines this, it clashes. The fix must come from UAMMD, I reckon.