### PR TITLE
Pass all real architectures to nvcc when building the conda package

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -17,9 +17,9 @@ jobs:
         shell: bash -el {0}
     strategy:
       matrix:
-        cuda-version: ["12.1", "12.3", "12.6", "12.9"]
+        cuda-version: ["12.9"]
         include:
-          - cuda-version: "12.1"
+          - cuda-version: "12.9"
             build-py-wrapper: true
     steps:
       - uses: actions/checkout@v4

--- a/devtools/conda-build/build.sh
+++ b/devtools/conda-build/build.sh
@@ -2,7 +2,16 @@ set -x
 SRC_DIR=$(pwd)
 TMPDIR=$(mktemp -d)
 cd $TMPDIR
-cmake $SRC_DIR -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_BUILD_TYPE=Release -DINSTALL_PYTHON_PACKAGE=ON -DBUILD_PYTHON_WRAPPER=ON -DCMAKE_CUDA_ARCHITECTURES=all-major  -DPython_EXECUTABLE=${PYTHON} -DUAMMD_PRECISION=$UAMMD_PRECISION -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=256
+if [ -z ${CUDAARCHS+x} ]; then
+  CUDAARCHS=$(nvcc --list-gpu-code | tr ' ' '\n' \
+      | grep -E '^sm_[0-9]+$' \
+      | sed 's/sm_//;s/$/-real/' \
+      | paste -sd';' -)
+  # Add the virtual architecture of the latest
+  LATEST_ARCH=$(echo $CUDAARCHS | tr ';' '\n' | sort -V | tail -n1 | sed 's/-real//')
+  CUDAARCHS="${CUDAARCHS};${LATEST_ARCH}"
+fi
+cmake $SRC_DIR -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_BUILD_TYPE=Release -DINSTALL_PYTHON_PACKAGE=ON -DBUILD_PYTHON_WRAPPER=ON -DCMAKE_CUDA_ARCHITECTURES=${CUDAARCHS} -DPython_EXECUTABLE=${PYTHON} -DUAMMD_PRECISION=$UAMMD_PRECISION -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=256
 make -j4
 make install
 rm -rf $TMPDIR

--- a/devtools/conda-build/build.sh
+++ b/devtools/conda-build/build.sh
@@ -2,6 +2,7 @@ set -x
 SRC_DIR=$(pwd)
 TMPDIR=$(mktemp -d)
 cd $TMPDIR
+
 if [ -z ${CUDAARCHS+x} ]; then
   CUDAARCHS=$(nvcc --list-gpu-code | tr ' ' '\n' \
       | grep -E '^sm_[0-9]+$' \

--- a/devtools/conda-build/meta.yaml
+++ b/devtools/conda-build/meta.yaml
@@ -7,7 +7,6 @@ source:
 
 build:
   number: 0
-  string: cuda{{ CUDA_VERSION | replace('.', '') }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
   script_env:
     - UAMMD_PRECISION    
 requirements:
@@ -22,7 +21,6 @@ requirements:
     - cmake >=3.27
     - pybind11
     - gxx
-    - cuda-version {{ CUDA_VERSION }}
     - cuda-nvcc
     - make
     - pip
@@ -34,7 +32,6 @@ requirements:
     - liblapacke
     - blas-devel
     - cuda-libraries-dev
-    - cuda-version {{ CUDA_VERSION }}
     - python
     - deepdiff
     - jsbeautifier
@@ -45,7 +42,6 @@ requirements:
     - jsbeautifier
     - cuda-cudart
     - cuda-libraries
-    - cuda-version {{ CUDA_VERSION }}    
 
 
 test:

--- a/devtools/conda-build/meta.yaml
+++ b/devtools/conda-build/meta.yaml
@@ -7,6 +7,7 @@ source:
 
 build:
   number: 0
+  string: cuda{{ CUDA_VERSION | replace('.', '') }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
   script_env:
     - UAMMD_PRECISION    
 requirements:


### PR DESCRIPTION
An alias has been added to the Conda building process so the cuda version is general